### PR TITLE
Consume absolute values for aggregation

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -46,6 +46,8 @@ type Metric struct {
 	LineCoverage        float64 `sql:"not null" json:"lineCoverage"`
 	ConditionalCoverage float64 `sql:"not null" json:"conditionalCoverage"`
 	Timestamp           int64   `sql:"not null" json:"timestamp"`
+	LinesCovered        int64   `sql:"" json:"linesCovered"`
+	LinesTested         int64   `sql:"" json:"linesTested"`
 }
 
 type errorResponse struct {


### PR DESCRIPTION
This is a proposal/WIP to consume absolute line coverage numbers in addition to the current percentages. This information is useful for aggregating coverage data from multiple sources.

A corresponding diff in jenkins-phabricator-plugin (https://github.com/uber/phabricator-jenkins-plugin/pull/249) would be responsible for emitting this data.

The new columns are intentionally nullable to be compatible with existing tables.

I have no intention of landing this -- anyone is free to pick it up. This would certainly need some additional testing.