### PR TITLE
Add LinesCovered and LinesTested to the Metrics model for aggregation

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -46,6 +46,8 @@ type Metric struct {
 	LineCoverage        float64 `sql:"not null" json:"lineCoverage"`
 	ConditionalCoverage float64 `sql:"not null" json:"conditionalCoverage"`
 	Timestamp           int64   `sql:"not null" json:"timestamp"`
+	LinesCovered        int64   `sql:"not null" json:"linesCovered"`
+	LinesTested         int64   `sql:"not null" json:"linesTested"`
 }
 
 type errorResponse struct {


### PR DESCRIPTION
This is a follow up of this PR https://github.com/uber/uberalls/pull/29

The only difference is LinesCovered and LinesTested are not nullable. If they are nullable, there is issues decoding existing values. gorm will auto migrate the schema, and default values will be 0.